### PR TITLE
enforce certain twoFactorRoles

### DIFF
--- a/middleware/client.js
+++ b/middleware/client.js
@@ -232,7 +232,9 @@ exports.checkPhonenumberAuth = (errorCallback) => {
  * Check if 2FA is required and for what roles
  */
 exports.check2FA = (req, res, next) => {
-  const twoFactorRoles =  req.client.twoFactorRoles;
+  const twoFactorRolesFromSettings =  req.client.twoFactorRoles;
+  const enforcedTwoFactorRoles = ["admin", "moderator", "editor"];
+  const twoFactorRoles = [...new Set([...twoFactorRolesFromSettings, ...enforcedTwoFactorRoles])]
 
   // if no role is present, assume default role
   const userRole = req.user.role ? req.user.role : defaultRole;


### PR DESCRIPTION
Enforce 2-factor authentication for moderator, editor and admin roles.
For the member-role, the 2-factor authentication is still a setting in the admin panel (but almost never used in practice).